### PR TITLE
Update gulp-sass to avoid failed npm update

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "gulp-clean-css": "^2.0.13",
     "gulp-concat": "^2.6.0",
     "gulp-jsmin": "^0.1.5",
-    "gulp-sass": "^2.3.2",
+    "gulp-sass": "^3.0.0",
     "gulp-zip": "^3.2.0",
     "node-sass": "^3.4.2"
   },


### PR DESCRIPTION
This upgrades the gulp-sass version to ^3.0.0 to avoid the issue of node-sass@3.13.1 not being available.
Solution comes from;
https://github.com/codecombat/codecombat/issues/4430#issuecomment-348927771

Clippings from the error output;
```
Downloading binary from https://github.com/sass/node-sass/releases/download/v3.13.1/darwin-x64-79_binding.node
Cannot download "https://github.com/sass/node-sass/releases/download/v3.13.1/darwin-x64-79_binding.node":

HTTP error 404 Not Found
```

```
1 error generated.
make: *** [Release/obj.target/binding/src/create_string.o] Error 1
gyp ERR! build error
gyp ERR! stack Error: `make` failed with exit code: 2
gyp ERR! stack     at ChildProcess.onExit (/Users/garretthyder/Work/WordPress/plugin-scaffold/wp-content/plugins/sendtonews/node_modules/node-gyp/lib/build.js:262:23)
gyp ERR! stack     at ChildProcess.emit (events.js:321:20)
gyp ERR! stack     at Process.ChildProcess._handle.onexit (internal/child_process.js:275:12)
gyp ERR! System Darwin 19.2.0
gyp ERR! command "/usr/local/Cellar/node/13.6.0/bin/node" "/Users/garretthyder/Work/WordPress/plugin-scaffold/wp-content/plugins/sendtonews/node_modules/node-gyp/bin/node-gyp.js" "rebuild" "--verbose" "--libsass_ext=" "--libsass_cflags=" "--libsass_ldflags=" "--libsass_library="
gyp ERR! cwd /Users/garretthyder/Work/WordPress/plugin-scaffold/wp-content/plugins/sendtonews/node_modules/node-sass
gyp ERR! node -v v13.6.0
gyp ERR! node-gyp -v v3.8.0
gyp ERR! not ok
Build failed with error code: 1
npm WARN sendtonews@0.2.0 No repository field.
npm WARN sendtonews@0.2.0 No license field.

npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! node-sass@3.13.1 postinstall: `node scripts/build.js`
npm ERR! Exit status 1
npm ERR!
npm ERR! Failed at the node-sass@3.13.1 postinstall script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.
```
